### PR TITLE
Fix -503 timeout/timedout RPC error when providing an offset beyond file size in upload.getFile

### DIFF
--- a/downloader.go
+++ b/downloader.go
@@ -118,6 +118,7 @@ func (d *Downloader) DownloadFileToPath(
 		}
 	}
 
+	d.log.Warn("calling DownloadFileParts: fpath: %s size: %d, partSize: %d, offset: %d", fpath, size, partSize, offset)
 	partsRes, err := d.DownloadFileParts(fd, fileLocation, dcID, size, partSize, offset, progressHnd)
 	if err != nil {
 		return nil, merry.Wrap(err)
@@ -140,7 +141,9 @@ func (d *Downloader) DownloadFileParts(
 	partsRes := &FilePartsResult{ActualDcID: dcID}
 
 	partsCount := int((size - offset + partSize - 1) / partSize)
+	d.log.Warn("DownloadFileParts: partsCount: %d", partsCount)
 	resChans := make([]chan *FileResponse, clampI(1, partsCount, 4))
+	d.log.Warn("DownloadFileParts: len(resChans): %d", len(resChans))
 
 	for i := 0; i < len(resChans); i++ {
 		resChans[i] = d.ReqestFilePart(dcID, fileLocation, size,

--- a/downloader.go
+++ b/downloader.go
@@ -143,7 +143,7 @@ func (d *Downloader) DownloadFileParts(
 	resChans := make([]chan *FileResponse, clampI(1, partsCount, 4))
 
 	for i := 0; i < len(resChans); i++ {
-		resChans[i] = d.ReqestFilePart(dcID, fileLocation,
+		resChans[i] = d.ReqestFilePart(dcID, fileLocation, size,
 			offset+partSize*int64(i), partSize)
 	}
 
@@ -163,7 +163,7 @@ func (d *Downloader) DownloadFileParts(
 		}
 		newPartOffset := offset + partSize*int64(len(resChans)-1)
 		if newPartOffset < size || len(resChans) == 1 {
-			resChans[len(resChans)-1] = d.ReqestFilePart(dcID, fileLocation, newPartOffset, partSize)
+			resChans[len(resChans)-1] = d.ReqestFilePart(dcID, fileLocation, size, newPartOffset, partSize)
 		} else {
 			resChans = resChans[:len(resChans)-1]
 		}
@@ -185,7 +185,10 @@ func (d *Downloader) DownloadFileParts(
 	return partsRes, nil
 }
 
-func (d *Downloader) ReqestFilePart(dcID int32, fileLocation mtproto.TL, offset, limit int64) chan *FileResponse {
+func (d *Downloader) ReqestFilePart(dcID int32, fileLocation mtproto.TL, totalSize, offset, limit int64) chan *FileResponse {
+	if totalSize-offset < limit {
+		limit = totalSize - offset
+	}
 	part := &filePart{
 		dcID:     dcID,
 		location: fileLocation,

--- a/downloader.go
+++ b/downloader.go
@@ -187,7 +187,11 @@ func (d *Downloader) DownloadFileParts(
 
 func (d *Downloader) ReqestFilePart(dcID int32, fileLocation mtproto.TL, totalSize, offset, limit int64) chan *FileResponse {
 	if totalSize-offset < limit {
+		d.log.Warn("ReqestFilePart: totalSize: %d, offset: %d, limit: %d; adjusting limit to %d", totalSize, offset, limit, totalSize-offset)
 		limit = totalSize - offset
+		if limit < 0 {
+			limit = 0
+		}
 	}
 	part := &filePart{
 		dcID:     dcID,

--- a/downloader.go
+++ b/downloader.go
@@ -165,7 +165,7 @@ func (d *Downloader) DownloadFileParts(
 			resChans[i-1] = resChans[i]
 		}
 		newPartOffset := offset + partSize*int64(len(resChans)-1)
-		if newPartOffset < size || len(resChans) == 1 {
+		if newPartOffset < size {
 			resChans[len(resChans)-1] = d.ReqestFilePart(dcID, fileLocation, size, newPartOffset, partSize)
 		} else {
 			resChans = resChans[:len(resChans)-1]
@@ -180,7 +180,7 @@ func (d *Downloader) DownloadFileParts(
 		}
 		partsRes.BytesWritten += n
 
-		if len(res.Data) < int(partSize) {
+		if newPartOffset >= size {
 			partsRes.Finished = true
 			break
 		}

--- a/downloader.go
+++ b/downloader.go
@@ -186,13 +186,7 @@ func (d *Downloader) DownloadFileParts(
 }
 
 func (d *Downloader) ReqestFilePart(dcID int32, fileLocation mtproto.TL, totalSize, offset, limit int64) chan *FileResponse {
-	if totalSize-offset < limit {
-		d.log.Warn("ReqestFilePart: totalSize: %d, offset: %d, limit: %d; adjusting limit to %d", totalSize, offset, limit, totalSize-offset)
-		limit = totalSize - offset
-		if limit < 0 {
-			limit = 0
-		}
-	}
+	d.log.Warn("ReqestFilePart: totalSize: %d, offset: %d, limit: %d", totalSize, offset, limit)
 	part := &filePart{
 		dcID:     dcID,
 		location: fileLocation,

--- a/downloader.go
+++ b/downloader.go
@@ -118,7 +118,6 @@ func (d *Downloader) DownloadFileToPath(
 		}
 	}
 
-	d.log.Warn("calling DownloadFileParts: fpath: %s size: %d, partSize: %d, offset: %d", fpath, size, partSize, offset)
 	partsRes, err := d.DownloadFileParts(fd, fileLocation, dcID, size, partSize, offset, progressHnd)
 	if err != nil {
 		return nil, merry.Wrap(err)
@@ -141,12 +140,10 @@ func (d *Downloader) DownloadFileParts(
 	partsRes := &FilePartsResult{ActualDcID: dcID}
 
 	partsCount := int((size - offset + partSize - 1) / partSize)
-	d.log.Warn("DownloadFileParts: partsCount: %d", partsCount)
 	resChans := make([]chan *FileResponse, clampI(1, partsCount, 4))
-	d.log.Warn("DownloadFileParts: len(resChans): %d", len(resChans))
 
 	for i := 0; i < len(resChans); i++ {
-		resChans[i] = d.ReqestFilePart(dcID, fileLocation, size,
+		resChans[i] = d.ReqestFilePart(dcID, fileLocation,
 			offset+partSize*int64(i), partSize)
 	}
 
@@ -166,7 +163,7 @@ func (d *Downloader) DownloadFileParts(
 		}
 		newPartOffset := offset + partSize*int64(len(resChans)-1)
 		if newPartOffset < size {
-			resChans[len(resChans)-1] = d.ReqestFilePart(dcID, fileLocation, size, newPartOffset, partSize)
+			resChans[len(resChans)-1] = d.ReqestFilePart(dcID, fileLocation, newPartOffset, partSize)
 		} else {
 			resChans = resChans[:len(resChans)-1]
 		}
@@ -188,8 +185,7 @@ func (d *Downloader) DownloadFileParts(
 	return partsRes, nil
 }
 
-func (d *Downloader) ReqestFilePart(dcID int32, fileLocation mtproto.TL, totalSize, offset, limit int64) chan *FileResponse {
-	d.log.Warn("ReqestFilePart: totalSize: %d, offset: %d, limit: %d", totalSize, offset, limit)
+func (d *Downloader) ReqestFilePart(dcID int32, fileLocation mtproto.TL, offset, limit int64) chan *FileResponse {
 	part := &filePart{
 		dcID:     dcID,
 		location: fileLocation,

--- a/downloader.go
+++ b/downloader.go
@@ -107,7 +107,7 @@ func (d *Downloader) DownloadFileToPath(
 		return nil, merry.Wrap(err)
 	}
 	if offset%int64(partSize) != 0 {
-		d.log.Warn("file '%s' exists but size is not multiple of block size (%d % %d != 0), moving to start",
+		d.log.Warn("file '%s' exists but size is not multiple of block size (%d %% %d != 0), moving to start",
 			tempFpath, offset, partSize)
 		offset, err = fd.Seek(0, io.SeekStart)
 		if err != nil {
@@ -177,7 +177,7 @@ func (d *Downloader) DownloadFileParts(
 		}
 		partsRes.BytesWritten += n
 
-		if newPartOffset >= size {
+		if len(resChans) == 0 {
 			partsRes.Finished = true
 			break
 		}

--- a/mtproto/mtproto.go
+++ b/mtproto/mtproto.go
@@ -518,7 +518,7 @@ func (m *MTProto) SendSyncRetry(
 		}
 
 		// TL_rpc_error{ErrorCode:-503, ErrorMessage:"Timeout"}
-		if IsError(res, "Timeout") {
+		if IsError(res, "Timeout") || IsError(res, "Timedout") {
 			m.log.Warn("got RPC timeout, retrying in %s", failRetryInterval)
 			time.Sleep(failRetryInterval)
 			continue

--- a/mtproto/mtproto.go
+++ b/mtproto/mtproto.go
@@ -518,6 +518,7 @@ func (m *MTProto) SendSyncRetry(
 		}
 
 		// TL_rpc_error{ErrorCode:-503, ErrorMessage:"Timeout"}
+		// UPD: seems the message was checnged to "Timedout". Not sure is old one is absolete or not. Checking both just in case.
 		if IsError(res, "Timeout") || IsError(res, "Timedout") {
 			m.log.Warn("got RPC timeout, retrying in %s", failRetryInterval)
 			time.Sleep(failRetryInterval)


### PR DESCRIPTION
According to https://github.com/pyrogram/pyrogram/issues/664#issuecomment-990718395 , now `upload.getFile` sometimes just doesn't accept  `offset` that is larger than file size; thus the following patch to avoid this kind of request which would result in server-side `-503 "Timeout" / "Timedout"` RPC error.